### PR TITLE
Make SerializableBSONObject.checkID return a new doc, so it can work with immutable doc types

### DIFF
--- a/bson-driver/src/main/scala/SerializableBSONObject.scala
+++ b/bson-driver/src/main/scala/SerializableBSONObject.scala
@@ -45,13 +45,15 @@ trait SerializableBSONObject[T] {
   def checkKeys(doc: T): Unit
 
   /**
-   * Checks for an ID and generates one.
+   * Checks for an ID and generates one, returning a new doc with the id.
+   * The new doc may be a mutation of the old doc, OR a new object
+   * if the old doc was immutable.
    * Not all implementers will need this, but it gets invoked nonetheless
    * as a signal to BSONDocument, etc implementations to verify an id is there 
    * and generate one if needed.
    *
    */
-  def checkID(doc: T): Unit
+  def checkID(doc: T): T
 
   def _id(doc: T): Option[AnyRef]
 

--- a/bson-driver/src/main/scala/collection/Implicits.scala
+++ b/bson-driver/src/main/scala/collection/Implicits.scala
@@ -82,22 +82,25 @@ object `package` {
      * as a signal to BSONDocument, etc implementations to verify an id is there 
      * and generate one if needed.
      */
-    def checkID(doc: T) = doc.get("_id") match {
-      case Some(oid: ObjectId) => {
-        log.debug("Found an existing OID")
-        oid.notNew()
-        //oid
+    def checkID(doc: T) : T = {
+      doc.get("_id") match {
+        case Some(oid: ObjectId) => {
+          log.debug("Found an existing OID")
+          oid.notNew()
+          //oid
+        }
+        case Some(other) => {
+          log.debug("Found a non-OID ID")
+          //other
+        }
+        case None => {
+          val oid = new ObjectId()
+          doc.put("_id", oid)
+          log.trace("no ObjectId. Generated: %s", doc.get("_id"))
+          //oid
+        }
       }
-      case Some(other) => {
-        log.debug("Found a non-OID ID")
-        //other
-      }
-      case None => {
-        val oid = new ObjectId()
-        doc.put("_id", oid)
-        log.trace("no ObjectId. Generated: %s", doc.get("_id"))
-        //oid
-      }
+      doc
     }
     
     def _id(doc: T): Option[AnyRef] = doc.getAs[AnyRef]("_id")


### PR DESCRIPTION
Make SerializableBSONObject.checkID return a new doc, so it can work with immutable doc types

Caller must replace the doc with the returned one.
