### PR TITLE
Preallocate dynamic send buffer to 256 bytes not 16M

### DIFF
--- a/mongo-driver/src/main/scala/MongoConnection.scala
+++ b/mongo-driver/src/main/scala/MongoConnection.scala
@@ -519,8 +519,7 @@ object MongoConnection extends Logging {
     require(channel.isConnected, "Channel is closed.")
     val isWrite = f.isInstanceOf[WriteRequestFuture]
     // TODO - Better pre-estimation of buffer size - We don't have a length attributed to the Message yet
-    val outStream = new ChannelBufferOutputStream(ChannelBuffers.dynamicBuffer(ByteOrder.LITTLE_ENDIAN,
-      if (maxBSONObjectSize > 0) maxBSONObjectSize else 1024 * 1024 * 4))
+    val outStream = new ChannelBufferOutputStream(ChannelBuffers.dynamicBuffer(ByteOrder.LITTLE_ENDIAN, 256))
     log.trace("Put msg id: %s f: %s into dispatcher: %s", msg.requestID, f, dispatcher)
     log.trace("PreWrite with outStream '%s'", outStream)
     /**


### PR DESCRIPTION
It's a dynamic buffer, so should cleanly scale up
if there's an actual large message.

In my benchmarks this is a 10x-100x speedup since
we no longer initialize a 16M array on every send.
It gets Hammersmith to the same order of magnitude
performance-wise as Casbah.
