### PR TITLE
Avoid copying bytes twice when reading replies

### DIFF
--- a/mongo-driver/src/main/scala/wire/ReplyMessage.scala
+++ b/mongo-driver/src/main/scala/wire/ReplyMessage.scala
@@ -87,11 +87,12 @@ object ReplyMessage extends Logging {
         in.read(l)
         val len = Bits.readInt(l)
         log.debug("Decoding object, length: %d", len)
-        val b = Array.ofDim[Byte](len - 4)
-        in.read(b)
-        val n = Array.concat(l, b)
-        log.trace("Len: %s L: %s / %s, Header: %s", len, l, readInt(l), readInt(n))
-        n
+        val b = Array.ofDim[Byte](len)
+        in.read(b, 4, len - 4)
+        // copy length to the full array
+        Array.copy(l, 0, b, 0, 4)
+        log.trace("Len: %s L: %s / %s, Header: %s", len, l, readInt(l), readInt(b))
+        b
       }
 
       val documents = for (i <- 0 until numReturned) yield _dec


### PR DESCRIPTION
This seems to be a 40%-plus speedup when reading a large reply.
It doesn't matter very much if the reply is small.

Do take these benchmark numbers with some salt, they are pretty erratic from run to run. But, the code fixed here was clearly a hot-spot in the profiler.

Before

[info]   one large       (Hammersmith)                 0.933 ms/request average over 1000 iterations
[info]   one large async (Hammersmith)                 0.420 ms/request average over 100 iterations
[info]   one small       (Hammersmith)                 0.287 ms/request average over 8000 iterations
[info]   one small async (Hammersmith)                 0.057 ms/request average over 1000 iterations

After

[info]   one large       (Hammersmith)                 0.587 ms/request average over 1000 iterations
[info]   one large async (Hammersmith)                 0.301 ms/request average over 100 iterations
[info]   one small       (Hammersmith)                 0.280 ms/request average over 8000 iterations
[info]   one small async (Hammersmith)                 0.056 ms/request average over 1000 iterations
