### PR TITLE
Make requestID field in MongoMessage immutable

### DIFF
--- a/mongo-driver/src/main/scala/wire/WireProtocol.scala
+++ b/mongo-driver/src/main/scala/wire/WireProtocol.scala
@@ -177,7 +177,7 @@ abstract class MongoMessage extends Logging {
   /* Standard Message Header */
   //val header: MessageHeader
   val opCode: OpCode.Value
-  var requestID = MongoMessage.ID.getAndIncrement
+  val requestID = MongoMessage.ID.getAndIncrement
   log.trace("Generated Message ID '%s'", requestID)
 
   //  def apply(channel: Channel) = write


### PR DESCRIPTION
It doesn't seem to ever get modified, and this is
the only reason MongoMessage is mutable it looks like.
